### PR TITLE
Global exception handler

### DIFF
--- a/src/main/java/nl/laura/boekenapi/exception/GlobalExceptionHandler.java
+++ b/src/main/java/nl/laura/boekenapi/exception/GlobalExceptionHandler.java
@@ -1,0 +1,64 @@
+package nl.laura.boekenapi.exception;
+
+import org.springframework.http.*;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+
+import java.time.OffsetDateTime;
+import java.util.stream.Collectors;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    public record ApiError(OffsetDateTime timestamp, int status, String message, String path) {}
+
+    private ResponseEntity<ApiError> build(HttpStatus status, String message, WebRequest req) {
+        String path = req.getDescription(false).replace("uri=", "");
+        return ResponseEntity.status(status)
+                .body(new ApiError(OffsetDateTime.now(), status.value(), message, path));
+    }
+
+    // 400 voor validatie
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiError> handleValidation(MethodArgumentNotValidException ex, WebRequest req) {
+        String msg = ex.getBindingResult().getFieldErrors().stream()
+                .map(e -> e.getField() + ": " + e.getDefaultMessage())
+                .collect(Collectors.joining("; "));
+        return build(HttpStatus.BAD_REQUEST, msg, req);
+    }
+
+    // 400 voor verkeerde body
+    @ExceptionHandler({HttpMessageNotReadableException.class, MethodArgumentTypeMismatchException.class})
+    public ResponseEntity<ApiError> handleBadInput(Exception ex, WebRequest req) {
+        return build(HttpStatus.BAD_REQUEST, "Ongeldige gegevens", req);
+    }
+
+    // 403 – geen toestemming (komt uit Spring Security)
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ApiError> handleAccessDenied(AccessDeniedException ex, WebRequest req) {
+        return build(HttpStatus.FORBIDDEN, "Geen toestemming", req);
+    }
+
+    // 404 – Niet gevonden
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ResponseEntity<ApiError> handleNotFound(ResourceNotFoundException ex, WebRequest req) {
+        return build(HttpStatus.NOT_FOUND, ex.getMessage(), req);
+    }
+
+    // 409 – Duplicaat
+    @ExceptionHandler(DuplicateResourceException.class)
+    public ResponseEntity<ApiError> handleDuplicate(DuplicateResourceException ex, WebRequest req) {
+        return build(HttpStatus.CONFLICT, ex.getMessage(), req);
+    }
+
+    // 500 – alles wat niet expliciet is afgevangen
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiError> handleOther(Exception ex, WebRequest req) {
+        return build(HttpStatus.INTERNAL_SERVER_ERROR, "Unexpected error", req);
+    }
+}
+

--- a/src/main/java/nl/laura/boekenapi/security/SecurityConfig.java
+++ b/src/main/java/nl/laura/boekenapi/security/SecurityConfig.java
@@ -1,4 +1,3 @@
-// src/main/java/nl/laura/boekenapi/security/SecurityConfig.java
 package nl.laura.boekenapi.security;
 
 import org.springframework.context.annotation.Bean;
@@ -8,28 +7,18 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
-@Profile("dev") // alleen actief in het dev-profiel
+@Profile("dev")
 public class SecurityConfig {
 
     @Bean
     SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         return http
-                // 1) H2-console toestaan
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/h2-console/**").permitAll()
-                        .anyRequest().permitAll()   // voor nu alles vrij in dev
+                        .anyRequest().permitAll()
                 )
-                // 2) CSRF uit (minimaal voor H2)
-                //    Wil je CSRF niet overal uit? Gebruik de ignoring-variant hieronder.
                 .csrf(csrf -> csrf.disable())
-                // .csrf(csrf -> csrf.ignoringRequestMatchers("/h2-console/**"))
-
-                // 3) Frames toestaan vanaf dezelfde origin (anders blijven de frames grijs)
                 .headers(headers -> headers.frameOptions(frame -> frame.sameOrigin()))
-
-                // 4) Basic mag, maar is niet nodig als alles permitAll is
-                //.httpBasic(Customizer.withDefaults())
-
                 .build();
     }
 }

--- a/src/test/java/nl/laura/boekenapi/service/LibraryServiceTest.java
+++ b/src/test/java/nl/laura/boekenapi/service/LibraryServiceTest.java
@@ -32,10 +32,8 @@ class LibraryServiceTest {
     @Mock private BookRepository bookRepository;
     @Mock private UserRepository userRepository;
 
-    // Echte mapper gebruiken, maar via Mockito beheren
     @Spy  private LibraryItemMapper libraryItemMapper = new LibraryItemMapper();
 
-    // Laat Mockito de constructor injecteren (niet zelf new-en!)
     @InjectMocks private LibraryService service;
 
     @Test


### PR DESCRIPTION
**Wat heb ik gedaan:**

- Centrale GlobalExceptionHandler toegevoegd (uniform JSON {timestamp,status,message,path}).
- Fouten afgevangen: 400 (validatie + parse/type), 404, 409, 500.
- BookControllerTest omgezet van platte tekst naar jsonPath asserts; extra tests voor 409 en kapotte JSON → 400.
- Controllers schoon gehouden; validatie via @Valid op DTO’s.

**Hoe heb ik getest:**

- JUnit controller-slice tests (@WebMvcTest + @Import(GlobalExceptionHandler)):
- GET /api/books/{id} onbekend → 404 + uniform JSON.
- POST /api/books met lege titel → 400 + uniform JSON (validatie).
- POST /api/books met kapotte JSON → 400 + uniform JSON (parse).
- Duplicaat bij create → 409 + uniform JSON.
- Alle bestaande happy-flow tests blijven groen (200/201/204 ongewijzigd).
