### PR TITLE
Admin uitgebreid met CRUD

### DIFF
--- a/src/main/java/nl/laura/boekenapi/controller/admin/AdminAuthorController.java
+++ b/src/main/java/nl/laura/boekenapi/controller/admin/AdminAuthorController.java
@@ -1,0 +1,49 @@
+package nl.laura.boekenapi.controller.admin;
+
+import jakarta.validation.Valid;
+import nl.laura.boekenapi.dto.AuthorRequest;
+import nl.laura.boekenapi.dto.AuthorResponse;
+import nl.laura.boekenapi.service.admin.AdminAuthorService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping(value = "/api/admin/authors", produces = MediaType.APPLICATION_JSON_VALUE)
+public class AdminAuthorController {
+
+    private final AdminAuthorService service;
+
+    public AdminAuthorController(AdminAuthorService service) {
+        this.service = service;
+    }
+
+    @GetMapping
+    public List<AuthorResponse> getAll() {
+        return service.getAll();
+    }
+
+    @GetMapping("/{id}")
+    public AuthorResponse getOne(@PathVariable Long id) {
+        return service.getById(id);
+    }
+
+    @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
+    @ResponseStatus(HttpStatus.CREATED)
+    public AuthorResponse create(@Valid @RequestBody AuthorRequest req) {
+        return service.create(req);
+    }
+
+    @PutMapping(value = "/{id}", consumes = MediaType.APPLICATION_JSON_VALUE)
+    public AuthorResponse update(@PathVariable Long id, @Valid @RequestBody AuthorRequest req) {
+        return service.update(id, req);
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable Long id) {
+        service.delete(id);
+    }
+}

--- a/src/main/java/nl/laura/boekenapi/controller/admin/AdminBookController.java
+++ b/src/main/java/nl/laura/boekenapi/controller/admin/AdminBookController.java
@@ -1,0 +1,52 @@
+package nl.laura.boekenapi.controller.admin;
+
+import jakarta.validation.Valid;
+import nl.laura.boekenapi.dto.BookRequest;
+import nl.laura.boekenapi.dto.BookResponse;
+import nl.laura.boekenapi.dto.BookUpdateRequest;
+import nl.laura.boekenapi.service.admin.AdminBookService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping(value = "/api/admin/books", produces = MediaType.APPLICATION_JSON_VALUE)
+@PreAuthorize("hasRole('ADMIN')")
+public class AdminBookController {
+
+    private final AdminBookService service;
+
+    public AdminBookController(AdminBookService service) {
+        this.service = service;
+    }
+
+    @GetMapping
+    public List<BookResponse> getAll() {
+        return service.getAll();
+    }
+
+    @GetMapping("/{id}")
+    public BookResponse getOne(@PathVariable Long id) {
+        return service.getById(id);
+    }
+
+    @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
+    @ResponseStatus(HttpStatus.CREATED)
+    public BookResponse create(@Valid @RequestBody BookRequest req) {
+        return service.create(req);
+    }
+
+    @PutMapping(value = "/{id}", consumes = MediaType.APPLICATION_JSON_VALUE)
+    public BookResponse update(@PathVariable Long id, @Valid @RequestBody BookUpdateRequest req) {
+        return service.update(id, req);
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable Long id) {
+        service.delete(id);
+    }
+}

--- a/src/main/java/nl/laura/boekenapi/controller/admin/AdminCategoryController.java
+++ b/src/main/java/nl/laura/boekenapi/controller/admin/AdminCategoryController.java
@@ -1,0 +1,51 @@
+package nl.laura.boekenapi.controller.admin;
+
+import jakarta.validation.Valid;
+import nl.laura.boekenapi.dto.CategoryRequest;
+import nl.laura.boekenapi.dto.CategoryResponse;
+import nl.laura.boekenapi.service.admin.AdminCategoryService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping(value = "/api/admin/categories", produces = MediaType.APPLICATION_JSON_VALUE)
+@PreAuthorize("hasRole('ADMIN')")
+public class AdminCategoryController {
+
+    private final AdminCategoryService service;
+
+    public AdminCategoryController(AdminCategoryService service) {
+        this.service = service;
+    }
+
+    @GetMapping
+    public List<CategoryResponse> getAll() {
+        return service.getAll();
+    }
+
+    @GetMapping("/{id}")
+    public CategoryResponse getOne(@PathVariable Long id) {
+        return service.getById(id);
+    }
+
+    @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
+    @ResponseStatus(HttpStatus.CREATED)
+    public CategoryResponse create(@Valid @RequestBody CategoryRequest req) {
+        return service.create(req);
+    }
+
+    @PutMapping(value = "/{id}", consumes = MediaType.APPLICATION_JSON_VALUE)
+    public CategoryResponse update(@PathVariable Long id, @Valid @RequestBody CategoryRequest req) {
+        return service.update(id, req);
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable Long id) {
+        service.delete(id);
+    }
+}

--- a/src/main/java/nl/laura/boekenapi/controller/admin/AdminUserController.java
+++ b/src/main/java/nl/laura/boekenapi/controller/admin/AdminUserController.java
@@ -1,0 +1,52 @@
+package nl.laura.boekenapi.controller.admin;
+
+import jakarta.validation.Valid;
+import nl.laura.boekenapi.dto.UserCreateRequest;
+import nl.laura.boekenapi.dto.UserResponse;
+import nl.laura.boekenapi.dto.UserUpdateRequest;
+import nl.laura.boekenapi.service.admin.AdminUserService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping(value = "/api/admin/users", produces = MediaType.APPLICATION_JSON_VALUE)
+@PreAuthorize("hasRole('ADMIN')")
+public class AdminUserController {
+
+    private final AdminUserService service;
+
+    public AdminUserController(AdminUserService service) {
+        this.service = service;
+    }
+
+    @GetMapping
+    public List<UserResponse> getAll() {
+        return service.getAll();
+    }
+
+    @GetMapping("/{id}")
+    public UserResponse getOne(@PathVariable Long id) {
+        return service.getById(id);
+    }
+
+    @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
+    @ResponseStatus(HttpStatus.CREATED)
+    public UserResponse create(@Valid @RequestBody UserCreateRequest req) {
+        return service.create(req);
+    }
+
+    @PutMapping(value = "/{id}", consumes = MediaType.APPLICATION_JSON_VALUE)
+    public UserResponse update(@PathVariable Long id, @Valid @RequestBody UserUpdateRequest req) {
+        return service.update(id, req);
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable Long id) {
+        service.delete(id);
+    }
+}

--- a/src/main/java/nl/laura/boekenapi/dto/UserCreateRequest.java
+++ b/src/main/java/nl/laura/boekenapi/dto/UserCreateRequest.java
@@ -1,0 +1,31 @@
+package nl.laura.boekenapi.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import nl.laura.boekenapi.model.Role;
+
+public class UserCreateRequest {
+
+    @NotBlank @Email
+    private String email;
+
+    @NotBlank @Size(min = 2, max = 100)
+    private String displayName;
+
+    @NotNull
+    private Role role;
+
+    @NotBlank @Size(min = 6, message = "Password must be at least 6 characters")
+    private String password;
+
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+    public String getDisplayName() { return displayName; }
+    public void setDisplayName(String displayName) { this.displayName = displayName; }
+    public Role getRole() { return role; }
+    public void setRole(Role role) { this.role = role; }
+    public String getPassword() { return password; }
+    public void setPassword(String password) { this.password = password; }
+}

--- a/src/main/java/nl/laura/boekenapi/dto/UserResponse.java
+++ b/src/main/java/nl/laura/boekenapi/dto/UserResponse.java
@@ -1,0 +1,28 @@
+package nl.laura.boekenapi.dto;
+
+import nl.laura.boekenapi.model.Role;
+
+public class UserResponse {
+    private Long id;
+    private String email;
+    private String displayName;
+    private Role role;
+
+    public UserResponse() {}
+
+    public UserResponse(Long id, String email, String displayName, Role role) {
+        this.id = id;
+        this.email = email;
+        this.displayName = displayName;
+        this.role = role;
+    }
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+    public String getDisplayName() { return displayName; }
+    public void setDisplayName(String displayName) { this.displayName = displayName; }
+    public Role getRole() { return role; }
+    public void setRole(Role role) { this.role = role; }
+}

--- a/src/main/java/nl/laura/boekenapi/dto/UserUpdateRequest.java
+++ b/src/main/java/nl/laura/boekenapi/dto/UserUpdateRequest.java
@@ -1,0 +1,16 @@
+package nl.laura.boekenapi.dto;
+
+import nl.laura.boekenapi.model.Role;
+
+public class UserUpdateRequest {
+    private String displayName;
+    private Role role;
+    private String password;
+
+    public String getDisplayName() { return displayName; }
+    public void setDisplayName(String displayName) { this.displayName = displayName; }
+    public Role getRole() { return role; }
+    public void setRole(Role role) { this.role = role; }
+    public String getPassword() { return password; }
+    public void setPassword(String password) { this.password = password; }
+}

--- a/src/main/java/nl/laura/boekenapi/exception/GlobalExceptionHandler.java
+++ b/src/main/java/nl/laura/boekenapi/exception/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.dao.DataIntegrityViolationException;
 
 import java.time.OffsetDateTime;
 import java.util.stream.Collectors;
@@ -69,6 +70,11 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(nl.laura.boekenapi.exception.FileStorageException.class)
     public ResponseEntity<ApiError> handleStorage(RuntimeException ex, WebRequest req) {
         return build(HttpStatus.BAD_REQUEST, ex.getMessage(), req);
+    }
+
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<ApiError> handleDataIntegrity(DataIntegrityViolationException ex, WebRequest req) {
+        return build(HttpStatus.CONFLICT, "Cannot delete: resource is still in use", req);
     }
 }
 

--- a/src/main/java/nl/laura/boekenapi/mapper/CategoryMapper.java
+++ b/src/main/java/nl/laura/boekenapi/mapper/CategoryMapper.java
@@ -8,7 +8,6 @@ import org.springframework.stereotype.Component;
 @Component
 public class CategoryMapper {
 
-    // Bestond al — laat zo
     public CategoryResponse toResponse(Category c) {
         if (c == null) return null;
         var dto = new CategoryResponse();

--- a/src/main/java/nl/laura/boekenapi/mapper/UserMapper.java
+++ b/src/main/java/nl/laura/boekenapi/mapper/UserMapper.java
@@ -1,0 +1,19 @@
+package nl.laura.boekenapi.mapper;
+
+import nl.laura.boekenapi.dto.UserResponse;
+import nl.laura.boekenapi.model.User;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserMapper {
+
+    public UserResponse toResponse(User user) {
+        if (user == null) return null;
+        UserResponse dto = new UserResponse();
+        dto.setId(user.getId());
+        dto.setEmail(user.getEmail());
+        dto.setDisplayName(user.getDisplayName());
+        dto.setRole(user.getRole());
+        return dto;
+    }
+}

--- a/src/main/java/nl/laura/boekenapi/repository/AuthorRepository.java
+++ b/src/main/java/nl/laura/boekenapi/repository/AuthorRepository.java
@@ -3,9 +3,6 @@ package nl.laura.boekenapi.repository;
 import nl.laura.boekenapi.model.Author;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
-
 public interface AuthorRepository extends JpaRepository<Author, Long> {
     boolean existsByNameIgnoreCase(String name);
-    Optional<Author> findByNameIgnoreCase(String name);
 }

--- a/src/main/java/nl/laura/boekenapi/repository/BookRepository.java
+++ b/src/main/java/nl/laura/boekenapi/repository/BookRepository.java
@@ -4,4 +4,7 @@ import nl.laura.boekenapi.model.Book;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BookRepository extends JpaRepository<Book, Long> {
+    boolean existsByAuthor_Id(Long authorId);
+    boolean existsByTitleIgnoreCaseAndAuthor_Id(String title, Long authorId);
+    boolean existsByCategory_Id(Long categoryId);
 }

--- a/src/main/java/nl/laura/boekenapi/service/admin/AdminAuthorService.java
+++ b/src/main/java/nl/laura/boekenapi/service/admin/AdminAuthorService.java
@@ -1,0 +1,81 @@
+package nl.laura.boekenapi.service.admin;
+
+import nl.laura.boekenapi.dto.AuthorRequest;
+import nl.laura.boekenapi.dto.AuthorResponse;
+import nl.laura.boekenapi.exception.DuplicateResourceException;
+import nl.laura.boekenapi.exception.ResourceNotFoundException;
+import nl.laura.boekenapi.mapper.AuthorMapper;
+import nl.laura.boekenapi.model.Author;
+import nl.laura.boekenapi.repository.AuthorRepository;
+import nl.laura.boekenapi.repository.BookRepository;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+
+@Service
+@Transactional
+public class AdminAuthorService {
+
+    private final AuthorRepository repo;
+    private final BookRepository bookRepo;
+    private final AuthorMapper mapper;
+
+    public AdminAuthorService(AuthorRepository repo, BookRepository bookRepo, AuthorMapper mapper) {
+        this.repo = repo;
+        this.bookRepo = bookRepo;
+        this.mapper = mapper;
+    }
+
+    public List<AuthorResponse> getAll() {
+        return repo.findAll().stream().map(mapper::toResponse).toList();
+    }
+
+    public AuthorResponse getById(Long id) {
+        Author a = repo.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Author not found: id=" + id));
+        return mapper.toResponse(a);
+    }
+
+    public AuthorResponse create(AuthorRequest req) {
+        if (repo.existsByNameIgnoreCase(req.getName())) {
+            throw new DuplicateResourceException("Author already exists: " + req.getName());
+        }
+        Author a = mapper.toEntity(req);
+        return mapper.toResponse(repo.save(a));
+    }
+
+    public AuthorResponse update(Long id, AuthorRequest req) {
+        Author a = repo.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Author not found: id=" + id));
+
+        if (!a.getName().equalsIgnoreCase(req.getName())
+                && repo.existsByNameIgnoreCase(req.getName())) {
+            throw new DuplicateResourceException("Author already exists: " + req.getName());
+        }
+
+        mapper.updateEntity(a, req);
+        return mapper.toResponse(repo.save(a));
+    }
+
+    public void delete(Long id) {
+        if (!repo.existsById(id)) {
+            throw new ResourceNotFoundException("Author not found: id=" + id);
+        }
+
+        if (bookRepo.existsByAuthor_Id(id)) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "Cannot delete author: books exist for this author");
+        }
+
+        try {
+            repo.deleteById(id);
+        } catch (DataIntegrityViolationException ex) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "Cannot delete author: books exist for this author");
+        }
+    }
+}

--- a/src/main/java/nl/laura/boekenapi/service/admin/AdminBookService.java
+++ b/src/main/java/nl/laura/boekenapi/service/admin/AdminBookService.java
@@ -1,0 +1,88 @@
+package nl.laura.boekenapi.service.admin;
+
+import nl.laura.boekenapi.dto.BookRequest;
+import nl.laura.boekenapi.dto.BookResponse;
+import nl.laura.boekenapi.dto.BookUpdateRequest;
+import nl.laura.boekenapi.exception.DuplicateResourceException;
+import nl.laura.boekenapi.exception.ResourceNotFoundException;
+import nl.laura.boekenapi.mapper.BookMapper;
+import nl.laura.boekenapi.model.Author;
+import nl.laura.boekenapi.model.Book;
+import nl.laura.boekenapi.model.Category;
+import nl.laura.boekenapi.repository.AuthorRepository;
+import nl.laura.boekenapi.repository.BookRepository;
+import nl.laura.boekenapi.repository.CategoryRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+public class AdminBookService {
+
+    private final BookRepository bookRepo;
+    private final AuthorRepository authorRepo;
+    private final CategoryRepository categoryRepo;
+    private final BookMapper mapper;
+
+    public AdminBookService(BookRepository bookRepo, AuthorRepository authorRepo,
+                            CategoryRepository categoryRepo, BookMapper mapper) {
+        this.bookRepo = bookRepo;
+        this.authorRepo = authorRepo;
+        this.categoryRepo = categoryRepo;
+        this.mapper = mapper;
+    }
+
+    public List<BookResponse> getAll() {
+        return bookRepo.findAll().stream().map(mapper::toResponse).toList();
+    }
+
+    public BookResponse getById(Long id) {
+        Book b = bookRepo.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Book not found: id=" + id));
+        return mapper.toResponse(b);
+    }
+
+    public BookResponse create(BookRequest req) {
+        Author a = authorRepo.findById(req.getAuthorId())
+                .orElseThrow(() -> new ResourceNotFoundException("Author not found: id=" + req.getAuthorId()));
+        Category c = categoryRepo.findById(req.getCategoryId())
+                .orElseThrow(() -> new ResourceNotFoundException("Category not found: id=" + req.getCategoryId()));
+
+        if (bookRepo.existsByTitleIgnoreCaseAndAuthor_Id(req.getTitle(), a.getId())) {
+            throw new DuplicateResourceException("Book already exists: " + req.getTitle() + " by this author");
+        }
+
+        Book b = mapper.toEntity(req, a, c);
+        return mapper.toResponse(bookRepo.save(b));
+    }
+
+    public BookResponse update(Long id, BookUpdateRequest req) {
+        Book b = bookRepo.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Book not found: id=" + id));
+
+        Author a = null;
+        if (req.getAuthorId() != null) {
+            a = authorRepo.findById(req.getAuthorId())
+                    .orElseThrow(() -> new ResourceNotFoundException("Author not found: id=" + req.getAuthorId()));
+        }
+
+        Category c = null;
+        if (req.getCategoryId() != null) {
+            c = categoryRepo.findById(req.getCategoryId())
+                    .orElseThrow(() -> new ResourceNotFoundException("Category not found: id=" + req.getCategoryId()));
+        }
+
+        mapper.updateEntity(req, b, a, c);
+
+        return mapper.toResponse(bookRepo.save(b));
+    }
+
+    public void delete(Long id) {
+        if (!bookRepo.existsById(id)) {
+            throw new ResourceNotFoundException("Book not found: id=" + id);
+        }
+        bookRepo.deleteById(id);
+    }
+}

--- a/src/main/java/nl/laura/boekenapi/service/admin/AdminCategoryService.java
+++ b/src/main/java/nl/laura/boekenapi/service/admin/AdminCategoryService.java
@@ -1,0 +1,72 @@
+package nl.laura.boekenapi.service.admin;
+
+import nl.laura.boekenapi.dto.CategoryRequest;
+import nl.laura.boekenapi.dto.CategoryResponse;
+import nl.laura.boekenapi.exception.DuplicateResourceException;
+import nl.laura.boekenapi.exception.ResourceNotFoundException;
+import nl.laura.boekenapi.mapper.CategoryMapper;
+import nl.laura.boekenapi.model.Category;
+import nl.laura.boekenapi.repository.BookRepository;
+import nl.laura.boekenapi.repository.CategoryRepository;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+
+@Service
+@Transactional
+public class AdminCategoryService {
+
+    private final CategoryRepository repo;
+    private final BookRepository bookRepo;
+    private final CategoryMapper mapper;
+
+    public AdminCategoryService(CategoryRepository repo,
+                                BookRepository bookRepo,
+                                CategoryMapper mapper) {
+        this.repo = repo;
+        this.bookRepo = bookRepo;
+        this.mapper = mapper;
+    }
+
+    public List<CategoryResponse> getAll() {
+        return repo.findAll().stream().map(mapper::toResponse).toList();
+    }
+
+    public CategoryResponse getById(Long id) {
+        Category c = repo.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Category not found: id=" + id));
+        return mapper.toResponse(c);
+    }
+
+    public CategoryResponse create(CategoryRequest req) {
+        if (repo.existsByNameIgnoreCase(req.getName())) {
+            throw new DuplicateResourceException("Category already exists: " + req.getName());
+        }
+        Category c = mapper.toEntity(req);
+        return mapper.toResponse(repo.save(c));
+    }
+
+    public CategoryResponse update(Long id, CategoryRequest req) {
+        Category c = repo.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Category not found: id=" + id));
+
+        if (!c.getName().equalsIgnoreCase(req.getName())
+                && repo.existsByNameIgnoreCase(req.getName())) {
+            throw new DuplicateResourceException("Category already exists: " + req.getName());
+        }
+
+        mapper.updateEntity(c, req);
+        return mapper.toResponse(repo.save(c));
+    }
+
+    public void delete(Long id) {
+        if (!repo.existsById(id)) {
+            throw new ResourceNotFoundException("Category not found: id=" + id);
+        }
+        repo.deleteById(id);
+    }
+}

--- a/src/main/java/nl/laura/boekenapi/service/admin/AdminUserService.java
+++ b/src/main/java/nl/laura/boekenapi/service/admin/AdminUserService.java
@@ -1,0 +1,81 @@
+package nl.laura.boekenapi.service.admin;
+
+import nl.laura.boekenapi.dto.UserCreateRequest;
+import nl.laura.boekenapi.dto.UserResponse;
+import nl.laura.boekenapi.dto.UserUpdateRequest;
+import nl.laura.boekenapi.exception.DuplicateResourceException;
+import nl.laura.boekenapi.exception.ResourceNotFoundException;
+import nl.laura.boekenapi.mapper.UserMapper;
+import nl.laura.boekenapi.model.User;
+import nl.laura.boekenapi.repository.UserRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+public class AdminUserService {
+
+    private final UserRepository repo;
+    private final PasswordEncoder encoder;
+    private final UserMapper mapper;
+
+    public AdminUserService(UserRepository repo, PasswordEncoder encoder, UserMapper mapper) {
+        this.repo = repo;
+        this.encoder = encoder;
+        this.mapper = mapper;
+    }
+
+    public List<UserResponse> getAll() {
+        return repo.findAll()
+                .stream()
+                .map(mapper::toResponse)
+                .toList();
+    }
+
+    public UserResponse getById(Long id) {
+        User u = repo.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("User not found: id=" + id));
+        return mapper.toResponse(u);
+    }
+
+    public UserResponse create(UserCreateRequest req) {
+        if (repo.findByEmailIgnoreCase(req.getEmail()).isPresent()) {
+            throw new DuplicateResourceException("Email already exists: " + req.getEmail());
+        }
+
+        User u = new User();
+        u.setEmail(req.getEmail().trim());
+        u.setDisplayName(req.getDisplayName().trim());
+        u.setRole(req.getRole());
+        u.setPasswordHash(encoder.encode(req.getPassword()));
+
+        return mapper.toResponse(repo.save(u));
+    }
+
+    public UserResponse update(Long id, UserUpdateRequest req) {
+        User u = repo.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("User not found: id=" + id));
+
+        if (req.getDisplayName() != null) {
+            u.setDisplayName(req.getDisplayName().trim());
+        }
+        if (req.getRole() != null) {
+            u.setRole(req.getRole());
+        }
+        if (req.getPassword() != null && !req.getPassword().isBlank()) {
+            u.setPasswordHash(encoder.encode(req.getPassword()));
+        }
+
+        return mapper.toResponse(repo.save(u));
+    }
+
+    public void delete(Long id) {
+        if (!repo.existsById(id)) {
+            throw new ResourceNotFoundException("User not found: id=" + id);
+        }
+        repo.deleteById(id);
+    }
+}

--- a/src/test/java/nl/laura/boekenapi/controller/AdminCategoryControllerTest.java
+++ b/src/test/java/nl/laura/boekenapi/controller/AdminCategoryControllerTest.java
@@ -1,0 +1,40 @@
+package nl.laura.boekenapi.controller;
+
+import nl.laura.boekenapi.dto.CategoryResponse;
+import nl.laura.boekenapi.service.admin.AdminCategoryService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("test")
+class AdminCategoryControllerTest {
+
+    @Autowired MockMvc mvc;
+    @MockBean AdminCategoryService service;
+
+    @Test
+    void adminCanCreateCategory_happyPath() throws Exception {
+        when(service.create(any())).thenReturn(new CategoryResponse()); // stub response
+
+        var json = """
+          {"name":"Stoicism"}
+        """;
+
+        mvc.perform(post("/api/admin/categories")
+                        .contentType(APPLICATION_JSON)
+                        .content(json))
+                .andExpect(status().isCreated());
+    }
+}

--- a/src/test/java/nl/laura/boekenapi/controller/FileControllerTest.java
+++ b/src/test/java/nl/laura/boekenapi/controller/FileControllerTest.java
@@ -20,7 +20,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest

--- a/src/test/java/nl/laura/boekenapi/controller/LibraryControllerTest.java
+++ b/src/test/java/nl/laura/boekenapi/controller/LibraryControllerTest.java
@@ -22,7 +22,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @SpringBootTest
-@AutoConfigureMockMvc(addFilters = false)   // security uit voor deze controller-test
+@AutoConfigureMockMvc(addFilters = false)
 @ActiveProfiles("dev")
 class LibraryControllerTest {
 

--- a/src/test/java/nl/laura/boekenapi/service/AdminUserServiceTest.java
+++ b/src/test/java/nl/laura/boekenapi/service/AdminUserServiceTest.java
@@ -1,0 +1,46 @@
+package nl.laura.boekenapi.service;
+
+import nl.laura.boekenapi.dto.UserCreateRequest;
+import nl.laura.boekenapi.exception.DuplicateResourceException;
+import nl.laura.boekenapi.mapper.UserMapper;
+import nl.laura.boekenapi.model.User;
+import nl.laura.boekenapi.repository.UserRepository;
+import nl.laura.boekenapi.service.admin.AdminUserService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AdminUserServiceTest {
+
+    @Mock UserRepository repo;
+    @Mock PasswordEncoder encoder;
+    @Mock UserMapper mapper;
+
+    @InjectMocks
+    AdminUserService service;
+
+    @Test
+    void createDuplicateEmail_throwsException() {
+        var req = new UserCreateRequest();
+        req.setEmail("test@example.com");
+        req.setDisplayName("Test");
+        req.setPassword("Secret123!");
+
+        when(repo.findByEmailIgnoreCase("test@example.com"))
+                .thenReturn(Optional.of(new User()));
+
+        assertThrows(DuplicateResourceException.class,
+                () -> service.create(req));
+
+        verify(repo, never()).save(any());
+    }
+}


### PR DESCRIPTION
**Wat heb ik gedaan:**
- CRUD-functionaliteit voor Users toegevoegd in admin-laag (controller, service, repository).
- Validaties: duplicate e-mail → 409, not found → 404.
- GlobalExceptionHandler gebruikt voor nette foutmeldingen.

**Hoe heb ik getest:**
- Met Postman alle CRUD-paden doorlopen.

**Korte samenvatting:**
- Nieuwe admin endpoints: /api/admin/users (create/read/update/delete).
- Veiligheid: alleen ROLE_ADMIN, JWT actief.